### PR TITLE
Set up linting for markdown files

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -10,13 +10,13 @@
     "allowed_elements": ["sub", "sup"]
   },
   "MD035": { // Horizontal rule style
-    "style": "----"
+    "style": "---"
   },
   "MD044": { // Proper names should have the correct capitalization
     "names": ["FoodRem"]
   },
   "MD046": { // Code block style
-    "style": "indented"
+    "style": "fenced"
   },
   "MD048": { // Code fence style
     "style": "backtick"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,30 @@
+{
+  "MD004": { // Unordered list style
+    "style": "asterisk"
+  },
+  "MD013": false, // Line length
+  "MD029": { // Ordered list item prefix
+    "style": "one"
+  },
+  "MD033": { // Inline HTML
+    "allowed_elements": ["sub", "sup"]
+  },
+  "MD035": { // Horizontal rule style
+    "style": "----"
+  },
+  "MD044": { // Proper names should have the correct capitalization
+    "names": ["FoodRem"]
+  },
+  "MD046": { // Code block style
+    "style": "indented"
+  },
+  "MD048": { // Code fence style
+    "style": "backtick"
+  },
+  "MD049": { //  Emphasis style should be consistent
+    "style": "underscore"
+  },
+  "MD050": { // Strong style should be consistent
+    "style": "asterisk"
+  }
+}

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -262,31 +262,33 @@ _{Explain here how the data archiving feature will be implemented}_
 **Target user profile**:  
 Purchasing managers who are proficient with typing for small F&B businesses
 
-
 **Value proposition**:  
 This application will help small businesses to manage perishable goods within a single inventory
 (no support for multiple inventories).
 
-
 ### User stories
+
 Add Inventory Item:
 
 Delete Inventory Item:
 
 Update inventory items:
+
 1. As a purchasing manager, I can rename my inventory items, so that I can update items with an incorrect name.
 2. As a purchasing manager, I can set the inventory quantity of my items.
 3. As a purchasing manager, I can set the date I bought my inventory, so that I know how long I have been keeping certain items.
-4. As a purchasing manager, I can set the date my inventory will expire, so that I know when certain items need to be consumed or used. 
+4. As a purchasing manager, I can set the date my inventory will expire, so that I know when certain items need to be consumed or used.
 5. As a purchasing manager, I can increase the inventory quantity of my items, so that I can keep my stock updated when I purchase new items.
 6. As a purchasing manager, I can decrease the inventory quantity of my items.
 
 View Inventory Items:
+
 1. As a purchasing manager, I can view all items in my inventory so that I can have an overview of all items and their details.
 2. As a purchasing manager, I can search for items by name, so that I can view a specific item and its associated details
 3. As a purchasing manager, I can search for items by tags, so that I can view all items that have the same tag.
 
 Tag Management System
+
 1. As a purchasing manager, I can view a list of tags.
 2. As a purchasing manager, I can create tags to classify inventory items.
 3. As a purchasing manager, I can rename a tag.
@@ -381,16 +383,18 @@ MSS:
    Use case ends.
 
 Extensions:
+
 - 1a. FoodRem detects that there is an issue with the command entered.
-    - 1a1. FoodRem requests for the command to be entered again.
-    - 1a2. User re-enters the command.
-    - Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
+
+  - 1a1. FoodRem requests for the command to be entered again.
+  - 1a2. User re-enters the command.
+  - Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
 
 - 3a. FoodRem detects that there is an issue with the command entered.
-    - 3a1. FoodRem requests for the command to be entered again.
-    - 3a2. User re-enters the command.
-    - Steps 3a1-3a2 are repeated until the command entered is correct.
-      Use case resumes from step 4.
+  - 3a1. FoodRem requests for the command to be entered again.
+  - 3a2. User re-enters the command.
+  - Steps 3a1-3a2 are repeated until the command entered is correct.
+    Use case resumes from step 4.
 
 #### UC7: Rename a tag
 
@@ -403,12 +407,13 @@ MSS:
 4. FoodRem informs user that the tag has been updated successfully.
 
 Extensions:
+
 - 3a. FoodRem detects that the new tag name already exist.
+
   - 3a1. FoodRem requests for a new tag name that does not exist.
   - 3a2. User re-enters the command to rename the desired tag.
   - Steps 3a1-3a2 are repeated until the data entered are correct.
     Use case resumes from step 4.
-
 
 - 3b. FoodRem detects that the name is in an incorrect format.
   - 3b1. FoodRem requests for a new tag name that follows an acceptable format.
@@ -422,23 +427,25 @@ Use Case: UC8 - Removing a tag from an item
 Preconditions: User knows the name of the tag they are removing from an item.
 
 MSS:
+
 1. User enters the command to find the item of interest.
 2. FoodRem shows a list containing possible matching items.
 3. User enters command to remove the tag from the desired items.
 4. FoodRem informs user that the tag has been updated successfully.
 
 Extensions:
+
 - 1a. FoodRem detects that there is an issue with the command entered.
+
   - 1a1. FoodRem requests for the command to be entered again.
   - 1a2. User re-enters the command.
   - Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
-
 
 - 3a. FoodRem detects that there is an issue with the command entered.
   - 3a1. FoodRem requests for the command to be entered again.
   - 3a2. User re-enters the command.
   - Steps 3a1-3a2 are repeated until the command entered is correct.
-  Use case resumes from step 4.
+    Use case resumes from step 4.
 
 #### UC9: Increment/Decrement Quantity of Item
 
@@ -461,7 +468,7 @@ MSS:
 2. User selects a criteria to sort the list by
 3. The list items are reordered according to the chosen criterion
 
-*{More to be added}*
+_{More to be added}_
 
 ### Non-Functional Requirements
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -3,14 +3,14 @@ layout: page
 title: Developer Guide
 ---
 
-- Table of Contents
+* Table of Contents
   {:toc}
 
 ---
 
 ## **Acknowledgements**
 
-- {list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}
+* {list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}
 
 ---
 
@@ -40,17 +40,17 @@ Given below is a quick overview of main components and how they interact with ea
 
 **`Main`** has two classes called [`Main`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/Main.java) and [`MainApp`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/MainApp.java). It is responsible for,
 
-- At app launch: Initializes the components in the correct sequence, and connects them up with each other.
-- At shut down: Shuts down the components and invokes cleanup methods where necessary.
+* At app launch: Initializes the components in the correct sequence, and connects them up with each other.
+* At shut down: Shuts down the components and invokes cleanup methods where necessary.
 
 [**`Commons`**](#common-classes) represents a collection of classes used by multiple other components.
 
 The rest of the App consists of four components.
 
-- [**`UI`**](#ui-component): The UI of the App.
-- [**`Logic`**](#logic-component): The command executor.
-- [**`Model`**](#model-component): Holds the data of the App in memory.
-- [**`Storage`**](#storage-component): Reads data from, and writes data to, the hard disk.
+* [**`UI`**](#ui-component): The UI of the App.
+* [**`Logic`**](#logic-component): The command executor.
+* [**`Model`**](#model-component): Holds the data of the App in memory.
+* [**`Storage`**](#storage-component): Reads data from, and writes data to, the hard disk.
 
 **How the architecture components interact with each other**
 
@@ -60,8 +60,8 @@ The _Sequence Diagram_ below shows how the components interact with each other f
 
 Each of the four main components (also shown in the diagram above),
 
-- defines its _API_ in an `interface` with the same name as the Component.
-- implements its functionality using a concrete `{Component Name}Manager` class (which follows the corresponding API `interface` mentioned in the previous point.
+* defines its _API_ in an `interface` with the same name as the Component.
+* implements its functionality using a concrete `{Component Name}Manager` class (which follows the corresponding API `interface` mentioned in the previous point.
 
 For example, the `Logic` component defines its API in the `Logic.java` interface and implements its functionality using the `LogicManager.java` class which follows the `Logic` interface. Other components interact with a given component through its interface rather than the concrete class (reason: to prevent outside component's being coupled to the implementation of a component), as illustrated in the (partial) class diagram below.
 
@@ -81,10 +81,10 @@ The `UI` component uses the JavaFx UI framework. The layout of these UI parts ar
 
 The `UI` component,
 
-- executes user commands using the `Logic` component.
-- listens for changes to `Model` data so that the UI can be updated with the modified data.
-- keeps a reference to the `Logic` component, because the `UI` relies on the `Logic` to execute commands.
-- depends on some classes in the `Model` component, as it displays `Person` object residing in the `Model`.
+* executes user commands using the `Logic` component.
+* listens for changes to `Model` data so that the UI can be updated with the modified data.
+* keeps a reference to the `Logic` component, because the `UI` relies on the `Logic` to execute commands.
+* depends on some classes in the `Model` component, as it displays `Person` object residing in the `Model`.
 
 ### Logic component
 
@@ -114,8 +114,8 @@ Here are the other classes in `Logic` (omitted from the class diagram above) tha
 
 How the parsing works:
 
-- When called upon to parse a user command, the `AddressBookParser` class creates an `XYZCommandParser` (`XYZ` is a placeholder for the specific command name e.g., `AddCommandParser`) which uses the other classes shown above to parse the user command and create a `XYZCommand` object (e.g., `AddCommand`) which the `AddressBookParser` returns back as a `Command` object.
-- All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
+* When called upon to parse a user command, the `AddressBookParser` class creates an `XYZCommandParser` (`XYZ` is a placeholder for the specific command name e.g., `AddCommandParser`) which uses the other classes shown above to parse the user command and create a `XYZCommand` object (e.g., `AddCommand`) which the `AddressBookParser` returns back as a `Command` object.
+* All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
 
 ### Model component
 
@@ -125,10 +125,10 @@ How the parsing works:
 
 The `Model` component,
 
-- stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
-- stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
-- stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
-- does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
+* stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
+* stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
+* stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
+* does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)
 
 <div markdown="span" class="alert alert-info">:information_source: **Note:** An alternative (arguably, a more OOP) model is given below. It has a `Tag` list in the `AddressBook`, which `Person` references. This allows `AddressBook` to only require one `Tag` object per unique tag, instead of each `Person` needing their own `Tag` objects.<br>
 
@@ -144,9 +144,9 @@ The `Model` component,
 
 The `Storage` component,
 
-- can save both address book data and user preference data in json format, and read them back into corresponding objects.
-- inherits from both `AddressBookStorage` and `UserPrefStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
-- depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
+* can save both address book data and user preference data in json format, and read them back into corresponding objects.
+* inherits from both `AddressBookStorage` and `UserPrefStorage`, which means it can be treated as either one (if only the functionality of only one is needed).
+* depends on some classes in the `Model` component (because the `Storage` component's job is to save/retrieve objects that belong to the `Model`)
 
 ### Common classes
 
@@ -164,9 +164,9 @@ This section describes some noteworthy details on how certain features are imple
 
 The proposed undo/redo mechanism is facilitated by `VersionedAddressBook`. It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`. Additionally, it implements the following operations:
 
-- `VersionedAddressBook#commit()` — Saves the current address book state in its history.
-- `VersionedAddressBook#undo()` — Restores the previous address book state from its history.
-- `VersionedAddressBook#redo()` — Restores a previously undone address book state from its history.
+* `VersionedAddressBook#commit()` — Saves the current address book state in its history.
+* `VersionedAddressBook#undo()` — Restores the previous address book state from its history.
+* `VersionedAddressBook#redo()` — Restores a previously undone address book state from its history.
 
 These operations are exposed in the `Model` interface as `Model#commitAddressBook()`, `Model#undoAddressBook()` and `Model#redoAddressBook()` respectively.
 
@@ -223,19 +223,19 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 <img src="images/CommitActivityDiagram.png" width="250" />
 
-#### Design considerations:
+#### Design considerations
 
 **Aspect: How undo & redo executes:**
 
-- **Alternative 1 (current choice):** Saves the entire address book.
+* **Alternative 1 (current choice):** Saves the entire address book.
 
-  - Pros: Easy to implement.
-  - Cons: May have performance issues in terms of memory usage.
+  * Pros: Easy to implement.
+  * Cons: May have performance issues in terms of memory usage.
 
-- **Alternative 2:** Individual command knows how to undo/redo by
+* **Alternative 2:** Individual command knows how to undo/redo by
   itself.
-  - Pros: Will use less memory (e.g. for `delete`, just save the person being deleted).
-  - Cons: We must ensure that the implementation of each individual command are correct.
+  * Pros: Will use less memory (e.g. for `delete`, just save the person being deleted).
+  * Cons: We must ensure that the implementation of each individual command are correct.
 
 _{more aspects and alternatives to be added}_
 
@@ -247,11 +247,11 @@ _{Explain here how the data archiving feature will be implemented}_
 
 ## **Documentation, logging, testing, configuration, dev-ops**
 
-- [Documentation guide](Documentation.md)
-- [Testing guide](Testing.md)
-- [Logging guide](Logging.md)
-- [Configuration guide](Configuration.md)
-- [DevOps guide](DevOps.md)
+* [Documentation guide](Documentation.md)
+* [Testing guide](Testing.md)
+* [Logging guide](Logging.md)
+* [Configuration guide](Configuration.md)
+* [DevOps guide](DevOps.md)
 
 ---
 
@@ -315,8 +315,8 @@ MSS:
 
 Extensions:
 
-- 1a. If the item name already exists in the inventory, FoodRem will throw an error.
-  - 1a1. User will re-enter command until the new item is correct.
+* 1a. If the item name already exists in the inventory, FoodRem will throw an error.
+  * 1a1. User will re-enter command until the new item is correct.
     Use case resumes from Step 2.
 
 #### UC2: Update Item in Inventory
@@ -330,8 +330,8 @@ MSS:
 
 Extensions:
 
-- 1a. If the item does not exist in the inventory, FoodRem will throw an error.
-  - 1a1. User will re-enter command until the correct item is given (i.e item exists in inventory).
+* 1a. If the item does not exist in the inventory, FoodRem will throw an error.
+  * 1a1. User will re-enter command until the correct item is given (i.e item exists in inventory).
     Use case resumes from Step 2.
 
 #### UC3: Delete Item from Inventory
@@ -345,8 +345,8 @@ MSS:
 
 Extensions:
 
-- 1a. Item does not exist in inventory.
-  - 1a1. FoodRem displays error to user that item does not exist in inventory.
+* 1a. Item does not exist in inventory.
+  * 1a1. FoodRem displays error to user that item does not exist in inventory.
     Use case resumes from step 1.
 
 #### UC4: Create Tag
@@ -358,8 +358,8 @@ MSS:
 
 Extensions:
 
-- 1a. Tag already exists.
-  - 1a1. FoodRem displays error warning to user.
+* 1a. Tag already exists.
+  * 1a1. FoodRem displays error warning to user.
     Use case resumes from step 1.
 
 #### UC5: Find Item
@@ -384,16 +384,16 @@ MSS:
 
 Extensions:
 
-- 1a. FoodRem detects that there is an issue with the command entered.
+* 1a. FoodRem detects that there is an issue with the command entered.
 
-  - 1a1. FoodRem requests for the command to be entered again.
-  - 1a2. User re-enters the command.
-  - Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
+  * 1a1. FoodRem requests for the command to be entered again.
+  * 1a2. User re-enters the command.
+  * Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
 
-- 3a. FoodRem detects that there is an issue with the command entered.
-  - 3a1. FoodRem requests for the command to be entered again.
-  - 3a2. User re-enters the command.
-  - Steps 3a1-3a2 are repeated until the command entered is correct.
+* 3a. FoodRem detects that there is an issue with the command entered.
+  * 3a1. FoodRem requests for the command to be entered again.
+  * 3a2. User re-enters the command.
+  * Steps 3a1-3a2 are repeated until the command entered is correct.
     Use case resumes from step 4.
 
 #### UC7: Rename a tag
@@ -408,17 +408,17 @@ MSS:
 
 Extensions:
 
-- 3a. FoodRem detects that the new tag name already exist.
+* 3a. FoodRem detects that the new tag name already exist.
 
-  - 3a1. FoodRem requests for a new tag name that does not exist.
-  - 3a2. User re-enters the command to rename the desired tag.
-  - Steps 3a1-3a2 are repeated until the data entered are correct.
+  * 3a1. FoodRem requests for a new tag name that does not exist.
+  * 3a2. User re-enters the command to rename the desired tag.
+  * Steps 3a1-3a2 are repeated until the data entered are correct.
     Use case resumes from step 4.
 
-- 3b. FoodRem detects that the name is in an incorrect format.
-  - 3b1. FoodRem requests for a new tag name that follows an acceptable format.
-  - 3b2. User re-enters the command to rename the desired tag.
-  - Steps 3b1-3b2 are repeated until the command entered is correct.
+* 3b. FoodRem detects that the name is in an incorrect format.
+  * 3b1. FoodRem requests for a new tag name that follows an acceptable format.
+  * 3b2. User re-enters the command to rename the desired tag.
+  * Steps 3b1-3b2 are repeated until the command entered is correct.
     Use case resumes from step 4.
 
 #### UC8: Removing a tag from an item
@@ -435,16 +435,16 @@ MSS:
 
 Extensions:
 
-- 1a. FoodRem detects that there is an issue with the command entered.
+* 1a. FoodRem detects that there is an issue with the command entered.
 
-  - 1a1. FoodRem requests for the command to be entered again.
-  - 1a2. User re-enters the command.
-  - Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
+  * 1a1. FoodRem requests for the command to be entered again.
+  * 1a2. User re-enters the command.
+  * Steps 1a1-1a2 are repeated until the command entered is correct. Use case resumes from step 2.
 
-- 3a. FoodRem detects that there is an issue with the command entered.
-  - 3a1. FoodRem requests for the command to be entered again.
-  - 3a2. User re-enters the command.
-  - Steps 3a1-3a2 are repeated until the command entered is correct.
+* 3a. FoodRem detects that there is an issue with the command entered.
+  * 3a1. FoodRem requests for the command to be entered again.
+  * 3a2. User re-enters the command.
+  * Steps 3a1-3a2 are repeated until the command entered is correct.
     Use case resumes from step 4.
 
 #### UC9: Increment/Decrement Quantity of Item
@@ -455,9 +455,9 @@ MSS:
 1. User increases/decreases the amount of the item in the inventory
    Extensions:
 
-- 1a. Item does not exist
-  - 1a1. FoodRem displays an error.
-  - 1a2. FoodRem asks the user if they want to try again
+* 1a. Item does not exist
+  * 1a1. FoodRem displays an error.
+  * 1a2. FoodRem asks the user if they want to try again
 
 #### UC10: Sorting List of Items by Criteria
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -270,6 +270,7 @@ Tags can be renamed and these changes would be reflected on all items immediatel
 
 {Image of entire application}
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -296,11 +297,13 @@ Tags can be renamed and these changes would be reflected on all items immediatel
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ## Flags
 
 Flags are delimiters that enable FoodRem to distinguish different parameters without ambiguity.
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -335,11 +338,13 @@ Flags are delimiters that enable FoodRem to distinguish different parameters wit
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ## Placeholders
 
 Placeholders are words in UPPER_CASE to show you what parameters you can supply to a command.
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -391,6 +396,7 @@ Placeholders are words in UPPER_CASE to show you what parameters you can supply 
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ## Features
 
@@ -656,6 +662,7 @@ bye
 
 ### Item Commands
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -702,9 +709,11 @@ bye
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ### Tag Commands
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -739,9 +748,11 @@ bye
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ### Other Commands
 
+<!-- markdownlint-disable no-inline-html -->
 <table>
 <thead>
   <tr>
@@ -764,6 +775,7 @@ bye
   </tr>
 </tbody>
 </table>
+<!-- markdownlint-enable no-inline-html -->
 
 ## Troubleshooting
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -421,7 +421,7 @@ What you should expect to find:
 
 #### Create a new item
 
-<!--- Remember to warn users if expiry date < bought date-->
+<!--- TODO: emember to warn users if expiry date < bought date-->
 
 Command: `item new ITEM_NAME`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -23,13 +23,13 @@ success story.
 ## Key Features
 
 1. Add, update and delete inventory items
-2. Search and sort food items by:
+1. Search and sort food items by:
    * Name
    * Quantity
    * Bought date
    * Expiry date
    * Tags
-3. Tag items to group them into categories
+1. Tag items to group them into categories
 
 ## Purpose, Scope and Audience
 
@@ -48,75 +48,43 @@ This guide is targeted at users using FoodRem who wants to find out more about t
 Readers do not have to be familiar with the command line to use this guide effectively.
 The only expectation we have of you is to carefully read through the different sections.
 
-<div style="page-break-after: always"></div> <! ---Testing line break-->
+<div style="page-break-after: always"></div> <!---Testing line break-->
 
-# Tables of Contents
+## Table of Contents
 
 1. [How to use the user guide](#how-to-use-the-user-guide)
-
-2. [Quick Start](#quick-start)
-
-3. [Items and Tags](#items-and-tags)
-
-4. [Navigating around the application](#navigating-around-the-application)
-
-5. [Flags](#flags)
-
-6. [Placeholders](#placeholders)
-
-7. [Features](#features)
-
+1. [Quick Start](#quick-start)
+1. [Items and Tags](#items-and-tags)
+1. [Navigating around the application](#navigating-around-the-application)
+1. [Flags](#flags)
+1. [Placeholders](#placeholders)
+1. [Features](#features)
    7.1. [Item Features](#item-features)
-
    &emsp; 7.1.1. [Create a new item](#create-a-new-item)
-
    &emsp; 7.1.2. [List all items](#list-all-items)
-
    &emsp; 7.1.3. [Search for an item](#search-for-an-item)
-
    &emsp; 7.1.4. [Sort all items by an attribute](#sort-all-items-by-an-attribute)
-
    &emsp; 7.1.5. [View the information of an item](#view-the-information-of-an-item)
-
    &emsp; 7.1.6. [Increase the quantity of an item](#increase-the-quantity-of-an-item)
-
    &emsp; 7.1.7. [Decrease the quantity of an item](#decrease-the-quantity-of-an-item)
-
    &emsp; 7.1.8. [Update the information of an item](#update-the-information-of-an-item)
-
    &emsp; 7.1.9. [Delete an item](#delete-an-item)
-
    7.2. [Tag Features](#tag-features)
-
    &emsp; 7.2.1. [Create a new tag](#create-a-new-tag)
-
    &emsp; 7.2.2. [List all tags](#list-all-tags)
-
    &emsp; 7.2.3. [Tag an item](#tag-an-item)
-
    &emsp; 7.2.4. [Untag an item](#untag-an-item)
-
    &emsp; 7.2.5. [Rename a tag](#rename-a-tag)
-
    &emsp; 7.2.6. [Delete a tag](#delete-an-item)
-
    7.3. [Receive help during usage](#receive-help-during-usage)
-
    7.4. [Reset the application](#reset-the-application)
-
    7.5. [Exit the application](#exit-the-application)
-
-8. [Command Summary](#command-summary)
-
-9. [Troubleshooting](#troubleshooting)
-
-10. [FAQ](#faq)
-
-11. [Future Extensions](#future-extensions)
-
-12. [Acknowledgements](#acknowledgements)
-
-13. [Glossary](#glossary)
+1. [Command Summary](#command-summary)
+1. [Troubleshooting](#troubleshooting)
+1. [FAQ](#faq)
+1. [Future Extensions](#future-extensions)
+1. [Acknowledgements](#acknowledgements)
+1. [Glossary](#glossary)
 
 ## How to use the User Guide
 
@@ -433,13 +401,13 @@ Example:
 
 Input
 
-```
+```text
 item new potato
 ```
 
 Output
 
-```
+```text
 Item  “potato” successfully created
 ```
 
@@ -455,13 +423,13 @@ Example:
 
 Input
 
-```
+```text
 list
 ```
 
 Output
 
-```
+```text
 Here are the items in your inventory:
 Onions
 Details about onions
@@ -488,13 +456,13 @@ Example:
 
 Input
 
-```
+```text
 find apple
 ```
 
 Output
 
-```
+```text
 Here are the results matching your search
 Green apple
 Rose apple
@@ -522,13 +490,13 @@ Example:
 
 Input
 
-```
+```text
 delete 1
 ```
 
 Output
 
-```
+```text
 (Item exists): Item “potato” successfully deleted!
 (Item does not exist): No item to be found at index 1. Use “list items” or “find NAME” to find the index of the item to be deleted.
 ```
@@ -551,13 +519,13 @@ Example:
 
 Input
 
-```
+```text
 list tags
 ```
 
 Output
 
-```
+```text
 Here are the tags that are available:
 Fruits
 Vegetables
@@ -584,13 +552,13 @@ Example:
 
 Input
 
-```
+```text
 help
 ```
 
 Output:
 
-```
+```text
 list:
     Lists all the items/tags that the user has created.
 
@@ -654,7 +622,7 @@ Example:
 
 Input
 
-```
+```text
 bye
 ```
 
@@ -793,14 +761,11 @@ Something goes here...
    **Glorified search and sort**
    a. Upgrade sort and search b. Sort food items by quantity c. Sort food items by name d. Sort food items by expiry
    date e. Sort food items by purchase date
-
-2. Food buffer a. Rainbow UI / Dashboard b. Optional : Minimum acceptable quantity c. Optional : Percentage of stock
+1. Food buffer a. Rainbow UI / Dashboard b. Optional : Minimum acceptable quantity c. Optional : Percentage of stock
    expiring
-
-3. Purchasing (Hard -> Will not see benefit immediately)
+1. Purchasing (Hard -> Will not see benefit immediately)
    a. History + Statistics b. Inventory need a price of items
-
-4. (Last priority) Order management a. Grouping of items b. Creation of menu with specific items c. Record menu items
+1. (Last priority) Order management a. Grouping of items b. Creation of menu with specific items c. Record menu items
    bought d. Statistics
 
 ## Acknowledgements

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,10 +11,10 @@ We want you to spend less time keeping track of perishable goods in your daily o
 FoodRem is a command line application that enables you to efficiently record, update and categorise food items.
 It is a convenient administrative tool that can answer the following questions in a flash:
 
-- What food items are about to expire?
-- How much of each condiment do I have?
-- Which food items are newly purchases?
-- ...and many more!
+* What food items are about to expire?
+* How much of each condiment do I have?
+* Which food items are newly purchases?
+* ...and many more!
 
 With a few quick commands, you can have complete control of your perishable goods, so you can focus on what
 is important: serving your customers, improving menu recipes, and transforming your business into the next
@@ -24,11 +24,11 @@ success story.
 
 1. Add, update and delete inventory items
 2. Search and sort food items by:
-   - Name
-   - Quantity
-   - Bought date
-   - Expiry date
-   - Tags
+   * Name
+   * Quantity
+   * Bought date
+   * Expiry date
+   * Tags
 3. Tag items to group them into categories
 
 ## Purpose, Scope and Audience
@@ -130,16 +130,16 @@ It is **highly recommended** that you read through the User Guide in a **sequent
 
 [Items and Tags](#items-and-tags) :
 
-- What FoodRem is capable of storing
+* What FoodRem is capable of storing
 
 [Navigating around the application](#navigating-around-the-application):
 
-- Terminologies of different parts of the application
-- What you are expected to see.
+* Terminologies of different parts of the application
+* What you are expected to see.
 
 [Flags](#flags) and [Placeholders](#placeholders):
 
-- Important syntax you will come across while reading the user
+* Important syntax you will come across while reading the user
   guide such as `n/`, `bgt/` or `INDEX`, `ITEM_NAME`.
 
 If you are confident, you can immediately refer to the [Command Summary](#command-summary)
@@ -147,8 +147,8 @@ after completing the [Quick Start](#quick-start).
 
 Meaning of icons:
 
-- ℹ️ : additional info
-- ❗ : warning
+* ℹ️ : additional info
+* ❗ : warning
 
 If you are stuck, refer to [Troubleshooting](#troubleshooting) or [FAQ](#faq).
 There is also a [Glossary](#glossary) that contains definitions of what common words
@@ -187,7 +187,7 @@ an expiry date for the potatoes.
 
 Note:
 
-- The [Placeholder](#placeholders) section covers the restrictions for respective placeholders.
+* The [Placeholder](#placeholders) section covers the restrictions for respective placeholders.
   For example, the date format of BOUGHT_DATE, certain characters you cannot use and the limit and precision of numbers.
 
 The command you would like to enter into the command box would be:
@@ -196,13 +196,13 @@ The command you would like to enter into the command box would be:
 
 Alternatively these commands would do the same thing:
 
-- `new n/Potatoesqty/30unit/kgbgt/05-09-22` (Omitting space between tags)
-- `new qty/30 n/Potatoes bgt/05-09-22 unit/kg` (Reordering the flags)
+* `new n/Potatoesqty/30unit/kgbgt/05-09-22` (Omitting space between tags)
+* `new qty/30 n/Potatoes bgt/05-09-22 unit/kg` (Reordering the flags)
 
 These commands are invalid:
 
-- `newn/Potatoesqty/30unit/kgbgt/05-09-22` (Removing space between command identifier and flag)
-- `new qty/-48 n/PÖtátÖes bgt/05/09/22 unit/|kg|` (Restrictions of placeholders not followed)
+* `newn/Potatoesqty/30unit/kgbgt/05-09-22` (Removing space between command identifier and flag)
+* `new qty/-48 n/PÖtátÖes bgt/05/09/22 unit/|kg|` (Restrictions of placeholders not followed)
 
 Find out more about restrictions in the sections [Flags](#flags), [Placeholders](#placeholders) and
 [Features](#features).
@@ -231,10 +231,10 @@ command, take note of the behaviour when certain tags are not included and restr
 
 Checklist before using a command:
 
-- [ ] I know the restrictions of the command
-- [ ] I know what flags are supplied to the command
-- [ ] I know the restrictions of each placeholder
-- [ ] I know the effects of not specifying each optional flag.
+* [ ] I know the restrictions of the command
+* [ ] I know what flags are supplied to the command
+* [ ] I know the restrictions of each placeholder
+* [ ] I know the effects of not specifying each optional flag.
 
 ## Items and Tags
 
@@ -243,11 +243,11 @@ Checklist before using a command:
 An item is a food item that you would like to include in FoodRem.
 The following are all the attributes store for each item:
 
-- Item name
-- Item quantity
-- Item unit (Unit of measurement e.g. `kg`, `packets`)
-- Item bought date
-- Item expiry date
+* Item name
+* Item quantity
+* Item unit (Unit of measurement e.g. `kg`, `packets`)
+* Item bought date
+* Item expiry date
 
 All items in FoodRem are unique. This means that no two items should have the same name.
 Uniqueness is not case-sensitive. "potato" and "POTATO" are treated as identical.
@@ -399,15 +399,15 @@ Before continuing, ensure you have read the section on [Flags](#flags) and [Plac
 
 What you should expect to find:
 
-- A description of the command
-- The expected behaviour for the command
-- A few valid and invalid examples of the command
-- Important points to note
+* A description of the command
+* The expected behaviour for the command
+* A few valid and invalid examples of the command
+* Important points to note
 
 **IMPORTANT:**
 
-- Square brackets indicate an optional parameter.
-- For each command, "Format" indicates the syntax of the command.
+* Square brackets indicate an optional parameter.
+* For each command, "Format" indicates the syntax of the command.
 
 ### Item Features
 
@@ -628,7 +628,7 @@ tag:
         Delete:      "tag delete food"
 
 bye:
-    Exits Foodrem program.
+    Exits FoodRem program.
 
     Usage:
         Exit:       "bye"

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -7,17 +7,17 @@ title: User Guide
 
 ## About
 
-We want you to spend less time keeping track of perishable goods in your daily operations. 
+We want you to spend less time keeping track of perishable goods in your daily operations.
 FoodRem is a command line application that enables you to efficiently record, update and categorise food items.
 It is a convenient administrative tool that can answer the following questions in a flash:
 
 - What food items are about to expire?
-- How much of each condiment do I have? 
+- How much of each condiment do I have?
 - Which food items are newly purchases?
 - ...and many more!
 
-With a few quick commands, you can have complete control of your perishable goods, so you can focus on what 
-is important: serving your customers, improving menu recipes, and transforming your business into the next 
+With a few quick commands, you can have complete control of your perishable goods, so you can focus on what
+is important: serving your customers, improving menu recipes, and transforming your business into the next
 success story.
 
 ## Key Features
@@ -39,13 +39,13 @@ FoodRem helps small businesses to easily manage consumables and perishable goods
 
 ### Scope
 
-This app is targeted at small F&B businesses which may struggle in inventory management due to a lack of streamlined process and manpower. 
+This app is targeted at small F&B businesses which may struggle in inventory management due to a lack of streamlined process and manpower.
 
 ### Audience
 
-This guide is targeted at users using FoodRem who wants to find out more about the different commands to manage their inventory in a quicker and more efficient manner. 
+This guide is targeted at users using FoodRem who wants to find out more about the different commands to manage their inventory in a quicker and more efficient manner.
 
-Readers do not have to be familiar with the command line to use this guide effectively. 
+Readers do not have to be familiar with the command line to use this guide effectively.
 The only expectation we have of you is to carefully read through the different sections.
 
 <div style="page-break-after: always"></div> <! ---Testing line break-->
@@ -73,7 +73,7 @@ The only expectation we have of you is to carefully read through the different s
    &emsp; 7.1.2. [List all items](#list-all-items)
 
    &emsp; 7.1.3. [Search for an item](#search-for-an-item)
-   
+
    &emsp; 7.1.4. [Sort all items by an attribute](#sort-all-items-by-an-attribute)
 
    &emsp; 7.1.5. [View the information of an item](#view-the-information-of-an-item)
@@ -123,31 +123,35 @@ The only expectation we have of you is to carefully read through the different s
 Thank you for choosing FoodRem! We are delighted to have you as a user and aim to serve you well!
 
 To gain the most out from this User Guide, start off with the [Quick Start](#quick-start) section.
-This will give you a brief overview about how to use this application. 
+This will give you a brief overview about how to use this application.
 
 It is **highly recommended** that you read through the User Guide in a **sequential order** up until the section
-[Features](#features) where you can find all the information you need for each command. 
+[Features](#features) where you can find all the information you need for each command.
 
-[Items and Tags](#items-and-tags) : 
+[Items and Tags](#items-and-tags) :
+
 - What FoodRem is capable of storing
 
-[Navigating around the application](#navigating-around-the-application): 
+[Navigating around the application](#navigating-around-the-application):
+
 - Terminologies of different parts of the application
 - What you are expected to see.
 
 [Flags](#flags) and [Placeholders](#placeholders):
+
 - Important syntax you will come across while reading the user
-guide such as `n/`, `bgt/` or `INDEX`, `ITEM_NAME`. 
+  guide such as `n/`, `bgt/` or `INDEX`, `ITEM_NAME`.
 
 If you are confident, you can immediately refer to the [Command Summary](#command-summary)
 after completing the [Quick Start](#quick-start).
 
 Meaning of icons:
+
 - ℹ️ : additional info
 - ❗ : warning
 
 If you are stuck, refer to [Troubleshooting](#troubleshooting) or [FAQ](#faq).
-There is also a [Glossary](#glossary) that contains definitions of what common words 
+There is also a [Glossary](#glossary) that contains definitions of what common words
 used in this application mean.
 
 It is time for you to unleash the potential of a command line application!
@@ -168,7 +172,7 @@ The first word of every command allows FoodRem to distinguish different commands
 `new` tells FoodRem that this is the command to create a new item.
 [Flags](#flags) such as `n/` and `qty/` are delimiters that enable FoodRem to distinguish different parameters
 supplied by you without ambiguity. [Placeholders](#placeholders) such as `ITEM_NAME` and `QUANTITY` shows you
-what you should place in each portion of the command. 
+what you should place in each portion of the command.
 
 Suppose you just bought 30 kg of potatoes, today is 5th September 22, and you do not feel the need to record
 an expiry date for the potatoes.
@@ -181,28 +185,31 @@ an expiry date for the potatoes.
 
 `BOUGHT_DATE`: 05-09-22
 
-Note: 
+Note:
+
 - The [Placeholder](#placeholders) section covers the restrictions for respective placeholders.
-For example, the date format of BOUGHT_DATE, certain characters you cannot use and the limit and precision of numbers.
+  For example, the date format of BOUGHT_DATE, certain characters you cannot use and the limit and precision of numbers.
 
 The command you would like to enter into the command box would be:
 
 `new n/Potatoes qty/30 unit/kg bgt/05-09-22`
 
 Alternatively these commands would do the same thing:
+
 - `new n/Potatoesqty/30unit/kgbgt/05-09-22` (Omitting space between tags)
 - `new qty/30 n/Potatoes bgt/05-09-22 unit/kg` (Reordering the flags)
 
 These commands are invalid:
+
 - `newn/Potatoesqty/30unit/kgbgt/05-09-22` (Removing space between command identifier and flag)
 - `new qty/-48 n/PÖtátÖes bgt/05/09/22 unit/|kg|` (Restrictions of placeholders not followed)
 
-Find out more about restrictions in the sections [Flags](#flags), [Placeholders](#placeholders) and 
+Find out more about restrictions in the sections [Flags](#flags), [Placeholders](#placeholders) and
 [Features](#features).
 
-Notice that there is a pair of square brackets [] surrounding some parameters like `qty/QUANTITY` 
+Notice that there is a pair of square brackets [] surrounding some parameters like `qty/QUANTITY`
 in the format. This indicates that the parameter is optional. Each of these placeholders have a default value
-based on the commands. These are documented in the [Features](#features) section for each command. 
+based on the commands. These are documented in the [Features](#features) section for each command.
 
 Let us try another command!
 
@@ -217,12 +224,13 @@ would like to enter into the command box is `inc id/12 qty/30`.
 Note: `INDEX_LIST` can be an `INDEX` (More information in [Placeholders](#placeholders))
 
 Now you should have a general sensing of how commands are used and how to interpret formats. All commands are
-consolidated in [Command Summary](#command-summary). However, it is **highly recommended** that you read through 
-the User Guide in a  **sequential order** up until the section [Features](#features) where you can find all the
-information you need for each command. This covers more details on syntax and common errors. Before using any 
+consolidated in [Command Summary](#command-summary). However, it is **highly recommended** that you read through
+the User Guide in a **sequential order** up until the section [Features](#features) where you can find all the
+information you need for each command. This covers more details on syntax and common errors. Before using any
 command, take note of the behaviour when certain tags are not included and restrictions.
 
 Checklist before using a command:
+
 - [ ] I know the restrictions of the command
 - [ ] I know what flags are supplied to the command
 - [ ] I know the restrictions of each placeholder
@@ -231,8 +239,10 @@ Checklist before using a command:
 ## Items and Tags
 
 ### Item
+
 An item is a food item that you would like to include in FoodRem.
 The following are all the attributes store for each item:
+
 - Item name
 - Item quantity
 - Item unit (Unit of measurement e.g. `kg`, `packets`)
@@ -242,7 +252,7 @@ The following are all the attributes store for each item:
 All items in FoodRem are unique. This means that no two items should have the same name.
 Uniqueness is not case-sensitive. "potato" and "POTATO" are treated as identical.
 
-FoodRem allows you to include an item that has an expiry date before a bought date. 
+FoodRem allows you to include an item that has an expiry date before a bought date.
 However, it will warn you that you are including an expired item into the inventory.
 
 Restrictions for other attributes can be found in [Placeholders](#placeholders).
@@ -252,9 +262,9 @@ Restrictions for other attributes can be found in [Placeholders](#placeholders).
 A tag serves as a means to categorise items. These tags are also unique and not case-sensitive.
 
 We can tag multiple items with the same tag and each item can have multiple tags. Tags are optional
-and serve as a means to easily categorise items. 
+and serve as a means to easily categorise items.
 
-Tags can be renamed and these changes would be reflected on all items immediately. 
+Tags can be renamed and these changes would be reflected on all items immediately.
 
 ## Navigating around the application
 
@@ -288,6 +298,7 @@ Tags can be renamed and these changes would be reflected on all items immediatel
 </table>
 
 ## Flags
+
 Flags are delimiters that enable FoodRem to distinguish different parameters without ambiguity.
 
 <table>
@@ -326,7 +337,9 @@ Flags are delimiters that enable FoodRem to distinguish different parameters wit
 </table>
 
 ## Placeholders
+
 Placeholders are words in UPPER_CASE to show you what parameters you can supply to a command.
+
 <table>
 <thead>
   <tr>
@@ -381,7 +394,7 @@ Placeholders are words in UPPER_CASE to show you what parameters you can supply 
 
 ## Features
 
-This section covers how to use each command in detail. 
+This section covers how to use each command in detail.
 Before continuing, ensure you have read the section on [Flags](#flags) and [Placeholders](#placeholders).
 
 What you should expect to find:
@@ -495,17 +508,20 @@ Rose apple
 
 Command: `[item] delete ITEM_INDEX`
 
-> Description: Deletes a specified item. Returns a warning if the item does not exist. 
+> Description: Deletes a specified item. Returns a warning if the item does not exist.
 
 ---
 
-Example: 
+Example:
 
 Input
+
 ```
 delete 1
 ```
+
 Output
+
 ```
 (Item exists): Item “potato” successfully deleted!
 (Item does not exist): No item to be found at index 1. Use “list items” or “find NAME” to find the index of the item to be deleted.


### PR DESCRIPTION
We are using the following VSCode extension: [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

Rules are configured in `.markdownlint.json`. UG and DG are also reformatted where deemed necessary.

Closes #167 