### PR TITLE
Modify increment and decrement command to have optional qty prefix

### DIFF
--- a/src/main/java/seedu/foodrem/logic/commands/itemcommands/DecrementCommand.java
+++ b/src/main/java/seedu/foodrem/logic/commands/itemcommands/DecrementCommand.java
@@ -15,21 +15,22 @@ import seedu.foodrem.model.Model;
 import seedu.foodrem.model.item.Item;
 import seedu.foodrem.model.item.ItemQuantity;
 
-
 /**
  * Increments the quantity of an item by a specified amount.
  */
 public class DecrementCommand extends Command {
     public static final String COMMAND_WORD = "dec";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Decrements the quantity of the item identified"
-            + "by the index number used in the displayed item list. "
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_ITEM_QUANTITY + "QUANTITY] "
-            + "Example: " + COMMAND_WORD + " 10 ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Decrements the quantity of the item identified by the index number used in the displayed item list.\n"
+            + "If a quantity is not provided, the item quantity will be decremented by 1. \n"
+            + "Parameters:\n"
+            + "INDEX (must be a positive integer) [" + PREFIX_ITEM_QUANTITY + "QUANTITY]\n"
+            + "Example:\n"
+            + COMMAND_WORD + " 10\n"
+            + COMMAND_WORD + " 10 " + PREFIX_ITEM_QUANTITY + "100";
 
     public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Decremented Item: %1$s";
-    public static final String MESSAGE_NOT_INCREMENTED = "Quantity to decrement by must be provided.";
     private final Index index;
     private final ItemQuantity quantity;
 

--- a/src/main/java/seedu/foodrem/logic/commands/itemcommands/IncrementCommand.java
+++ b/src/main/java/seedu/foodrem/logic/commands/itemcommands/IncrementCommand.java
@@ -22,14 +22,15 @@ public class IncrementCommand extends Command {
     public static final String COMMAND_WORD = "inc";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Increments the quantity of the item identified "
-            + "by the index number used in the displayed item list.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_ITEM_QUANTITY + "QUANTITY]\n"
-            + "Example: " + COMMAND_WORD + " 10 ";
+            + ": Increments the quantity of the item identified by the index number used in the displayed item list.\n"
+            + "If a quantity is not provided, the item quantity will be incremented by 1. \n"
+            + "Parameters:\n"
+            + "INDEX (must be a positive integer) [" + PREFIX_ITEM_QUANTITY + "QUANTITY]\n"
+            + "Example:\n"
+            + COMMAND_WORD + " 10\n"
+            + COMMAND_WORD + " 10 " + PREFIX_ITEM_QUANTITY + "100";
 
     public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Incremented Item: %1$s";
-    public static final String MESSAGE_NOT_INCREMENTED = "Quantity to increment by must be provided.";
     private final Index index;
     private final ItemQuantity quantity;
 

--- a/src/main/java/seedu/foodrem/logic/parser/DecrementCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/DecrementCommandParser.java
@@ -31,12 +31,16 @@ public class DecrementCommandParser implements Parser<DecrementCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DecrementCommand.MESSAGE_USAGE), pe);
         }
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)
-                || argMultimap.getPreamble().isEmpty()) {
+        // Default decrement by 1 if PREFIX_ITEM_QUANTITY not provided
+        ItemQuantity decrementQuantity = ParserUtil.parseQuantity("1");
+
+        if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DecrementCommand.MESSAGE_USAGE));
         }
 
-        ItemQuantity decrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));
+        if (arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)) {
+            decrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));
+        }
 
         return new DecrementCommand(index, decrementQuantity);
     }

--- a/src/main/java/seedu/foodrem/logic/parser/IncrementCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/IncrementCommandParser.java
@@ -31,12 +31,16 @@ public class IncrementCommandParser implements Parser<IncrementCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, IncrementCommand.MESSAGE_USAGE), pe);
         }
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)
-                || argMultimap.getPreamble().isEmpty()) {
+        // Default increment by 1 if PREFIX_ITEM_QUANTITY not provided
+        ItemQuantity incrementQuantity = ParserUtil.parseQuantity("1");
+
+        if (argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, IncrementCommand.MESSAGE_USAGE));
         }
 
-        ItemQuantity incrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));
+        if (arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)) {
+            incrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));
+        }
 
         return new IncrementCommand(index, incrementQuantity);
     }

--- a/src/main/java/seedu/foodrem/model/item/ItemQuantity.java
+++ b/src/main/java/seedu/foodrem/model/item/ItemQuantity.java
@@ -2,6 +2,7 @@ package seedu.foodrem.model.item;
 
 import static java.util.Objects.requireNonNull;
 
+import java.text.DecimalFormat;
 import java.util.function.BiFunction;
 
 import seedu.foodrem.model.item.itemvalidators.ItemQuantityValidator;
@@ -13,6 +14,7 @@ import seedu.foodrem.model.item.itemvalidators.ItemQuantityValidator;
  */
 public class ItemQuantity {
 
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.####");
     private static final double DEFAULT_QUANTITY = 0;
 
     private final double itemQuantity;
@@ -37,7 +39,7 @@ public class ItemQuantity {
                                                           ItemQuantity itemQuantity2,
                                                           BiFunction<Double, Double, Double> op) {
         double newQuantity = op.apply(itemQuantity1.itemQuantity, itemQuantity2.itemQuantity);
-        return new ItemQuantity(String.valueOf(newQuantity));
+        return new ItemQuantity(DECIMAL_FORMAT.format(newQuantity));
     }
 
     /**
@@ -55,16 +57,10 @@ public class ItemQuantity {
      * A value less than 0 is returned if the quantity is less than the other quantity and
      * a value greater than 0 if the quantity is greater than the other quantity.
      *
-     * @param other The ItemQuanitty to compare this ItemQuantity against.
+     * @param other The ItemQuantity to compare this ItemQuantity against.
      */
     public int compareTo(ItemQuantity other) {
-        if (itemQuantity < other.itemQuantity) {
-            return -1;
-        } else if (itemQuantity > other.itemQuantity) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return Double.compare(itemQuantity, other.itemQuantity);
     }
 
     /**
@@ -72,6 +68,6 @@ public class ItemQuantity {
      */
     @Override
     public String toString() {
-        return String.valueOf(itemQuantity);
+        return DECIMAL_FORMAT.format(itemQuantity);
     }
 }

--- a/src/main/java/seedu/foodrem/model/item/itemvalidators/ItemQuantityValidator.java
+++ b/src/main/java/seedu/foodrem/model/item/itemvalidators/ItemQuantityValidator.java
@@ -61,7 +61,7 @@ public class ItemQuantityValidator implements Validator {
         if (!itemQuantityString.contains(DECIMAL_POINT)) {
             return false;
         }
-        int numberOfDecimalPoints = itemQuantityString.length() - itemQuantityString.indexOf(DECIMAL_POINT);
+        int numberOfDecimalPoints = itemQuantityString.length() - itemQuantityString.indexOf(DECIMAL_POINT) - 1;
         return numberOfDecimalPoints > MAX_DECIMAL_PLACE;
     }
 


### PR DESCRIPTION
If the prefix is not provided, the quantity will be incremented or decremented by 1.

The quantity string representation is changed such that it will not show trailing 0s after the decimal place.

1.0 -> 1
1.1230 -> 1.123
1.010 -> 1.01