### PR TITLE
Fix broken JAR file CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
           java-package: jdk+fx
       - name: Create JAR file
         run: ./gradlew shadowJar
+      - name: Generate tag name from time
+        id: time
+        run: echo ::set-output name=NOW::$(echo ${{ github.event.repository.updated_at}} | sed -e 's/-//g' -e 's/T/-/g' -e 's/.\{4\}$/Z/' -e 's/://g')
       - name: Create release on GitHub
         id: create_release # We need the id to refer to it in the next step
         uses: actions/create-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: Auto-created release from ${{ github.ref }}
+          tag_name: ${{ steps.time.outputs.NOW }}
+          release_name: Auto-release ${{ github.event.repository.updated_at}}
+          body: 'Auto-created release from branch "${{ github.ref_name }}"'
       - name: Upload JAR file to GitHub releases
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
There was an error due to non-unique tag names earlier. This is fixed now by using the last commit time (repository update time) as the tag name.