### PR TITLE
Fix table markdown parsing

### DIFF
--- a/docs/_ug/commandSummary/ItemCommands.md
+++ b/docs/_ug/commandSummary/ItemCommands.md
@@ -12,6 +12,16 @@
 {% capture edit %}{% include_relative _ug/commandSummary/itemCommands/edit.md %}{% endcapture %}
 {% capture del %}{% include_relative _ug/commandSummary/itemCommands/del.md %}{% endcapture %}
 
+{% assign new = new | markdownify %}
+{% assign list = list | markdownify %}
+{% assign find = find | markdownify %}
+{% assign sort = sort | markdownify %}
+{% assign view = view | markdownify %}
+{% assign inc = inc | markdownify %}
+{% assign dec = dec | markdownify %}
+{% assign edit = edit | markdownify %}
+{% assign del = del | markdownify %}
+
 {% capture newexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/new.md %}{% endcapture %}
 {% capture listexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/list.md %}{% endcapture %}
 {% capture findexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/find.md %}{% endcapture %}
@@ -21,6 +31,16 @@
 {% capture decexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/dec.md %}{% endcapture %}
 {% capture editexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/edit.md %}{% endcapture %}
 {% capture delexample %}{% include_relative _ug/commandSummary/itemCommandsExamples/del.md %}{% endcapture %}
+
+{% assign newexample = newexample | markdownify %}
+{% assign listexample = listexample | markdownify %}
+{% assign findexample = findexample | markdownify %}
+{% assign sortexample = sortexample | markdownify %}
+{% assign viewexample = viewexample | markdownify %}
+{% assign incexample = incexample | markdownify %}
+{% assign decexample = decexample | markdownify %}
+{% assign editexample = editexample | markdownify %}
+{% assign delexample = delexample | markdownify %}
 <!-- markdownlint-restore -->
 
 <!-- ===== CREATE TABLE FORMATTING IN NORMAL+ MARKDOWN ===== -->

--- a/docs/_ug/commandSummary/OtherCommands.md
+++ b/docs/_ug/commandSummary/OtherCommands.md
@@ -6,10 +6,17 @@
 {% capture reset %}{% include_relative _ug/commandSummary/otherCommands/reset.md %}{% endcapture %}
 {% capture exit %}{% include_relative _ug/commandSummary/otherCommands/exit.md %}{% endcapture %}
 
+{% assign help = help | markdownify %}
+{% assign reset = reset | markdownify %}
+{% assign exit = exit | markdownify %}
+
 {% capture helpexample %}{% include_relative _ug/commandSummary/otherCommandsExamples/help.md %}{% endcapture %}
 {% capture resetexample %}{% include_relative _ug/commandSummary/otherCommandsExamples/reset.md %}{% endcapture %}
 {% capture exitexample %}{% include_relative _ug/commandSummary/otherCommandsExamples/exit.md %}{% endcapture %}
 
+{% assign helpexample = helpexample | markdownify %}
+{% assign resetexample = resetexample | markdownify %}
+{% assign exitexample = exitexample | markdownify %}
 <!-- markdownlint-restore -->
 
 <!-- ===== CREATE TABLE FORMATTING IN NORMAL+ MARKDOWN ===== -->

--- a/docs/_ug/commandSummary/TagCommands.md
+++ b/docs/_ug/commandSummary/TagCommands.md
@@ -10,6 +10,13 @@
 {% capture deletetag %}{% include_relative _ug/commandSummary/tagCommands/deletetag.md %}{% endcapture %}
 {% capture filtertag %}{% include_relative _ug/commandSummary/tagCommands/filtertag.md %}{% endcapture %}
 
+{% assign newtag = newtag | markdownify %}
+{% assign listtag = listtag | markdownify %}
+{% assign tag = tag | markdownify %}
+{% assign untag = untag | markdownify %}
+{% assign renametag = renametag | markdownify %}
+{% assign deletetag = deletetag | markdownify %}
+{% assign filtertag = filtertag | markdownify %}
 
 {% capture newtagexample %}{% include_relative _ug/commandSummary/tagCommandsExamples/newtag.md %}{% endcapture %}
 {% capture listtagexample %}{% include_relative _ug/commandSummary/tagCommandsExamples/listtag.md %}{% endcapture %}
@@ -19,6 +26,13 @@
 {% capture deletetagexample %}{% include_relative _ug/commandSummary/tagCommandsExamples/deletetag.md %}{% endcapture %}
 {% capture filtertagexample %}{% include_relative _ug/commandSummary/tagCommandsExamples/filtertag.md %}{% endcapture %}
 
+{% assign newtagexample = newtagexample | markdownify %}
+{% assign listtagexample = listtagexample | markdownify %}
+{% assign tagexample = tagexample | markdownify %}
+{% assign untagexample = untagexample | markdownify %}
+{% assign renametagexample = renametagexample | markdownify %}
+{% assign deletetagexample = deletetagexample | markdownify %}
+{% assign filtertagexample = filtertagexample | markdownify %}
 <!-- markdownlint-restore -->
 
 <!-- ===== CREATE TABLE FORMATTING IN NORMAL+ MARKDOWN ===== -->


### PR DESCRIPTION
<img width="806" alt="image" src="https://user-images.githubusercontent.com/34370238/197378528-57086426-9488-47ad-a09e-bfecd62b6100.png">

`Placeholders.md` is still using raw HTML for table cell contents so parsing it as Markdown will result in an additional bottom margin, so this change will be implemented later for this file.

Closes #268.