### PR TITLE
Show empty foodrem when data file is corrupted

### DIFF
--- a/src/main/java/seedu/foodrem/MainApp.java
+++ b/src/main/java/seedu/foodrem/MainApp.java
@@ -15,6 +15,7 @@ import seedu.foodrem.commons.util.ConfigUtil;
 import seedu.foodrem.commons.util.StringUtil;
 import seedu.foodrem.logic.Logic;
 import seedu.foodrem.logic.LogicManager;
+import seedu.foodrem.model.FoodRem;
 import seedu.foodrem.model.Model;
 import seedu.foodrem.model.ModelManager;
 import seedu.foodrem.model.ReadOnlyFoodRem;
@@ -83,13 +84,13 @@ public class MainApp extends Application {
             }
             initialData = foodRemOptional.orElseGet(SampleDataUtil::getSampleFoodRem);
         } catch (DataConversionException e) {
-            initialMessage = "Data file not in the correct format. Will be starting with a sample FoodRem";
+            initialMessage = "Data file not in the correct format. Will be starting with an empty FoodRem";
             logger.warning(initialMessage);
-            initialData = SampleDataUtil.getSampleFoodRem();
+            initialData = new FoodRem();
         } catch (IOException e) {
-            initialMessage = "Problem while reading from the file. Will be starting with a sample FoodRem";
+            initialMessage = "Problem while reading from the file. Will be starting with an empty FoodRem";
             logger.warning(initialMessage);
-            initialData = SampleDataUtil.getSampleFoodRem();
+            initialData = new FoodRem();
         }
 
         return new ModelManager(initialData, userPrefs);

--- a/src/main/java/seedu/foodrem/MainApp.java
+++ b/src/main/java/seedu/foodrem/MainApp.java
@@ -79,12 +79,12 @@ public class MainApp extends Application {
         try {
             Optional<ReadOnlyFoodRem> foodRemOptional = storage.readFoodRem();
             if (foodRemOptional.isEmpty()) {
-                initialMessage = "Data file not found. Will be starting with a sample FoodRem";
+                initialMessage = "Data file not found. Will be starting with a sample FoodRem.";
                 logger.info(initialMessage);
             }
             initialData = foodRemOptional.orElseGet(SampleDataUtil::getSampleFoodRem);
         } catch (DataConversionException e) {
-            initialMessage = "Data file not in the correct format. Will be starting with an empty FoodRem";
+            initialMessage = "Data file not in the correct format. Will be starting with an empty FoodRem.";
             logger.warning(initialMessage);
             initialData = new FoodRem();
         } catch (IOException e) {


### PR DESCRIPTION
As discussed over telegram between @RichDom2185 (blockquotes) and @yixiann:

> any reason we are changing the behaviour of the app? previously if no data => sample foodrem, corrupted data => empty. now all gives sample

I personally felt that it was better if we start with some data if the user corrupted the datafile

> cause I personally feel that if corrupted data, should start with empty, that way user:
> * immediately sees it's empty, goes to check, doesn't potentially miss out seed data as their own data
> * does not do any operations that may overwrite their existing (corrupted) data file just in case they only miss a comma or sth