### PR TITLE
Change bullet type for unlinted markdown segments

### DIFF
--- a/docs/_ug/placeholders/COMMAND_WORD.md
+++ b/docs/_ug/placeholders/COMMAND_WORD.md
@@ -2,7 +2,7 @@
 The COMMAND_WORD is a text indicating a command word of a command. Refer to the [Command Format](#command-format) for more info.
 
 ```info
-- COMMAND_WORD is **strictly** any of the following valid examples.
+* COMMAND_WORD is **strictly** any of the following valid examples.
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/EXPIRY_DATE.md
+++ b/docs/_ug/placeholders/EXPIRY_DATE.md
@@ -2,8 +2,8 @@
 The EXPIRY_DATE is the date indicating when an item will expire.
 
 ```info
-- EXPIRY_DATE must be in the following format (dd-mm-yyyy)
-- EXPIRY_DATE can only have years between 1900 and 2300 inclusive
+* EXPIRY_DATE must be in the following format (dd-mm-yyyy)
+* EXPIRY_DATE can only have years between 1900 and 2300 inclusive
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/INDEX.md
+++ b/docs/_ug/placeholders/INDEX.md
@@ -2,9 +2,9 @@
 The INDEX of an item is the number to the left of the item name in the Item List Box.
 
 ```info
-- INDEX is a whole number larger than 0
-- INDEX is dependent on the item list currently displayed in the Item List Box
-- Do not include a thousands-separator in INDEX
+* INDEX is a whole number larger than 0
+* INDEX is dependent on the item list currently displayed in the Item List Box
+* Do not include a thousands-separator in INDEX
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/KEYWORD.md
+++ b/docs/_ug/placeholders/KEYWORD.md
@@ -2,9 +2,9 @@
 The KEYWORD is the text we use to search for an item
 
 ```info
-- KEYWORD is a short text
-- KEYWORD can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
-- KEYWORD will have leading and trailing spaces trimmed
+* KEYWORD is a short text
+* KEYWORD can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
+* KEYWORD will have leading and trailing spaces trimmed
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/PRICE.md
+++ b/docs/_ug/placeholders/PRICE.md
@@ -2,10 +2,10 @@
 The PRICE is the number representing the cost of one unit of an item.
 
 ```info
-- PRICE is a number larger than 0
-- PRICE has an accuracy of 2 decimal places
-- PRICE has a limit of 1,000,000
-- Do not include thousands separators and currency symbols in PRICE
+* PRICE is a number larger than 0
+* PRICE has an accuracy of 2 decimal places
+* PRICE has a limit of 1,000,000
+* Do not include thousands separators and currency symbols in PRICE
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/QUANTITY.md
+++ b/docs/_ug/placeholders/QUANTITY.md
@@ -2,10 +2,10 @@
 The QUANTITY is the number representing the amount of an item.
 
 ```info
-- QUANTITY is a number larger than 0
-- QUANTITY has an accuracy of 4 decimal places
-- QUANTITY has a limit of 1,000,000
-- Do not include thousands separators and mathematical symbols in QUANTITY
+* QUANTITY is a number larger than 0
+* QUANTITY has an accuracy of 4 decimal places
+* QUANTITY has a limit of 1,000,000
+* Do not include thousands separators and mathematical symbols in QUANTITY
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/REMARKS.md
+++ b/docs/_ug/placeholders/REMARKS.md
@@ -2,9 +2,9 @@
 The REMARKS of an item is a remark/note that the user can add to an item.
 
 ```info
-- REMARKS is a short text with a limit of 1000 chracters
-- REMARKS can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
-- REMARKS will have leading and trailing spaces trimmed
+* REMARKS is a short text with a limit of 1000 chracters
+* REMARKS can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
+* REMARKS will have leading and trailing spaces trimmed
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/TAG_NAME.md
+++ b/docs/_ug/placeholders/TAG_NAME.md
@@ -2,11 +2,11 @@
 The TAG_NAME is the term we use to identify an item.
 
 ```info
-- TAG_NAME is a short text with a limit of 50 characters
-- TAG_NAME can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
-- TAG_NAME is unique and case-insensitive
-- TAG_NAME will have leading and trailing spaces trimmed
-- TAG_NAME cannot be blank
+* TAG_NAME is a short text with a limit of 50 characters
+* TAG_NAME can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
+* TAG_NAME is unique and case-insensitive
+* TAG_NAME will have leading and trailing spaces trimmed
+* TAG_NAME cannot be blank
 ```
 
 **Valid Examples:**

--- a/docs/_ug/placeholders/UNIT.md
+++ b/docs/_ug/placeholders/UNIT.md
@@ -2,10 +2,10 @@
 The UNIT is a text indicating the unit-of-measurement of an item.
 
 ```info
-- UNIT is a short text with a limit of 50 characters
-- UNIT can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
-- UNIT has a limit of 50 characters
-- UNIT will have leading and trailing spaces trimmed
+* UNIT is a short text with a limit of 50 characters
+* UNIT can contain alphanumeric characters, spaces, and the following symbols: `?` `'` `.` `"` `[` `]` `{` `}` `(` `)` `+` `^` `$` `*` `-` `,` `:` `;` `@` `!` `#` `%` `&` `_` `=`
+* UNIT has a limit of 50 characters
+* UNIT will have leading and trailing spaces trimmed
 ```
 
 **Valid Examples:**


### PR DESCRIPTION
The unlinted segments are due to our admonition syntax, escaping them as "code blocks".