### PR TITLE
Fix find command description in Command Summary

### DIFF
--- a/docs/_ug/commandSummary/itemCommands/find.md
+++ b/docs/_ug/commandSummary/itemCommands/find.md
@@ -1,4 +1,4 @@
 <!-- markdownlint-disable-file first-line-h1 -->
-`find KEYWORD [KEYWORD...]`
+`find KEYWORD [KEYWORD...]` _(Minimally one `KEYWORD` must be provided)_
 
 **Note**: You can provide multiple keywords to find an item. For example, `find potato chips yellow`.


### PR DESCRIPTION
Fixes #289 

Simply adds an additional note beside the command format.