### PR TITLE
Update hash fragment generation for glossary items

### DIFF
--- a/docs/_includes/glossary.md
+++ b/docs/_includes/glossary.md
@@ -10,7 +10,7 @@
 </thead>
 <!-- TODO: We need to manually check that the links work -->
 {% tablerow entry in filtered %}
-<a href="#{{ entry.name | slugify }}">{{ entry.name }}</a>
+<a href="#glossary-{{ entry.name | slugify }}">{{ entry.name }}</a>
 {% endtablerow %}
 </table>
 {: .glossary-quick-reference }
@@ -24,7 +24,7 @@
 <div markdown="1" class="glossary">
 {% for entry in group.items %}
 #### {{ entry.name }}
-{: .no_toc}
+{: .no_toc #glossary-{{ entry.name | slugify }}}
 
 <!-- markdownlint-disable-next-line no-inline-html -->
 <div markdown="1" class="glossary-body">


### PR DESCRIPTION
Use a custom-prefixed `id` and standardise slugification process for glossary items to guarantee bijective match between quick reference table and body contents.

Closes #327.