### PR TITLE
Prevent special chars in find command

### DIFF
--- a/src/main/java/seedu/foodrem/logic/parser/itemcommandparser/FindCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/itemcommandparser/FindCommandParser.java
@@ -3,6 +3,7 @@ package seedu.foodrem.logic.parser.itemcommandparser;
 import java.util.Arrays;
 
 import seedu.foodrem.commons.core.Messages;
+import seedu.foodrem.commons.util.StringUtil;
 import seedu.foodrem.logic.commands.itemcommands.FindCommand;
 import seedu.foodrem.logic.parser.Parser;
 import seedu.foodrem.logic.parser.exceptions.ParseException;
@@ -21,6 +22,11 @@ public class FindCommandParser implements Parser<FindCommand> {
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getUsage()));
+        }
+
+        if (!StringUtil.isValidString(trimmedArgs)) {
             throw new ParseException(
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.getUsage()));
         }

--- a/src/test/java/seedu/foodrem/logic/parser/itemcommandparser/FindCommandParserTest.java
+++ b/src/test/java/seedu/foodrem/logic/parser/itemcommandparser/FindCommandParserTest.java
@@ -27,6 +27,6 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, "Potato Cucumber", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Potato \n \t Cucumber  \t", expectedFindCommand);
+        assertParseSuccess(parser, "  Potato   Cucumber  ", expectedFindCommand);
     }
 }


### PR DESCRIPTION
I will modify find command to not accept

find n/Milk

as this will actually search for any items with the name "n/Milk" and make users think there is a bug. 

find Milk

will actually find the milk