### PR TITLE
Support autoglossary syntax

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,8 @@ collections:
 repository: "AY2223S1-CS2103T-W16-2/tp"
 github_icon: "images/github-icon.png"
 
-enable_admonitions: true
+enable_features:
+  admonitions: true
 
 defaults:
   - scope:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,6 +16,7 @@ github_icon: "images/github-icon.png"
 
 enable_features:
   admonitions: true
+  autoglossary: true
 
 defaults:
   - scope:

--- a/docs/_includes/autoglossary.liquid
+++ b/docs/_includes/autoglossary.liquid
@@ -1,6 +1,8 @@
 {% comment %}
   Copyright 2022 Richard Dominick
 {% endcomment %}
+{% capture newline %}
+{% endcapture %}
 {% assign entry_names = site.glossary | map: 'name' %}
 {% capture entry_keys %}{% for name in entry_names %}{{ name | downcase | slugify }};{% endfor %}{% endcapture %}
 {% assign entry_keys = entry_keys | split: ';' %}
@@ -15,7 +17,16 @@
   {% assign key = tag | first | strip %}
   {% assign label = tag | last | strip %}
   {%- if entry_keys contains key -%}
-    <a href="#glossary-{{ key }}">{{ label }}</a>
+    {%- for entry in site.glossary -%}
+      {%- if entry_keys[forloop.index0] == key -%}
+        <span class="def-tooltip">
+          <a href="#glossary-{{ key }}">{{ label }}</a>
+          <span class="popup">{{ entry.content | split: newline | first | markdownify | strip_html }}<br>
+            <i>Click to view glossary</i>
+          </span>
+        </span>{% break %}
+      {% endif %}
+    {% endfor %}
     {%- for tail in data offset:1 -%}
       {{ tail }}
     {%- endfor -%}

--- a/docs/_includes/autoglossary.liquid
+++ b/docs/_includes/autoglossary.liquid
@@ -1,0 +1,25 @@
+{% comment %}
+  Copyright 2022 Richard Dominick
+{% endcomment %}
+{% assign entry_names = site.glossary | map: 'name' %}
+{% capture entry_keys %}{% for name in entry_names %}{{ name | downcase | slugify }};{% endfor %}{% endcapture %}
+{% assign entry_keys = entry_keys | split: ';' %}
+{%- assign nodes = include.html
+  | strip
+  | split: '[['
+-%}
+{{ nodes.first }}
+{%- for node in nodes offset:1 -%}
+  {% assign data = node | split: ']]' %}
+  {% assign tag = data | first | strip | split: ':' %}
+  {% assign key = tag | first | strip %}
+  {% assign label = tag | last | strip %}
+  {%- if entry_keys contains key -%}
+    <a href="#glossary-{{ key }}">{{ label }}</a>
+    {%- for tail in data offset:1 -%}
+      {{ tail }}
+    {%- endfor -%}
+  {%-else -%}
+    [[{{ node }}
+  {%- endif -%}
+{%- endfor -%}

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% if site.enable_admonitions %}{% capture content %}{% include admonitions.liquid html=content %}{% endcapture %}{% endif %}
 <article class="post">
 
   <header class="post-header">
@@ -8,11 +9,7 @@ layout: default
   </header>
 
   <div class="post-content">
-    {% if site.enable_admonitions %}
-      {% include admonitions.liquid html=content %}
-    {% else %}
-      {{ content }}
-    {% endif %}
+    {{ content }}
   </div>
 
 </article>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-{% if site.enable_admonitions %}{% capture content %}{% include admonitions.liquid html=content %}{% endcapture %}{% endif %}
+{% if site.enable_features.admonitions %}{% capture content %}{% include admonitions.liquid html=content %}{% endcapture %}{% endif %}
 <article class="post">
   <header class="post-header">
     <h1 class="post-title">{{ page.title | escape }}</h1>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -3,13 +3,10 @@ layout: default
 ---
 {% if site.enable_admonitions %}{% capture content %}{% include admonitions.liquid html=content %}{% endcapture %}{% endif %}
 <article class="post">
-
   <header class="post-header">
     <h1 class="post-title">{{ page.title | escape }}</h1>
   </header>
-
   <div class="post-content">
     {{ content }}
   </div>
-
 </article>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 {% if site.enable_features.admonitions %}{% capture content %}{% include admonitions.liquid html=content %}{% endcapture %}{% endif %}
+{% if site.enable_features.autoglossary %}{% capture content %}{% include autoglossary.liquid html=content %}{% endcapture %}{% endif %}
 <article class="post">
   <header class="post-header">
     <h1 class="post-title">{{ page.title | escape }}</h1>

--- a/docs/_sass/foodrem.scss
+++ b/docs/_sass/foodrem.scss
@@ -254,6 +254,19 @@ html {
     left: 50%;
     text-align: center;
 
+    // Popup arrow
+    &::after {
+      $arrow-width: 5px;
+      content: "";
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      margin-left: -$arrow-width;
+      border-width: $arrow-width;
+      border-style: solid;
+      border-color: black transparent transparent transparent;
+    }
+
     :last-child {
       font-size: smaller;
       color: lightgray;

--- a/docs/_sass/foodrem.scss
+++ b/docs/_sass/foodrem.scss
@@ -228,6 +228,45 @@ html {
   }
 }
 
+.def-tooltip {
+  position: relative;
+  display: inline-block;
+
+  > .popup {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+
+    $width: 240%;
+    width: $width;
+    margin-left: calc(-#{$width} / 2);
+    box-sizing: border-box;
+    padding: 6px 10px;
+
+    background-color: rgba($color: black, $alpha: 0.9);
+    border-radius: 6px;
+    color: white;
+    font-size: small;
+
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    text-align: center;
+
+    :last-child {
+      font-size: smaller;
+      color: lightgray;
+    }
+
+    visibility: hidden;
+  }
+
+  &:hover > .popup {
+    visibility: visible;
+  }
+}
+
 article.post {
   a {
     color: #00769a;

--- a/docs/_sass/foodrem.scss
+++ b/docs/_sass/foodrem.scss
@@ -232,6 +232,11 @@ html {
   position: relative;
   display: inline-block;
 
+  > a {
+    color: inherit !important;
+    text-decoration: underline dotted;
+  }
+
   > .popup {
     -webkit-user-select: none;
     -moz-user-select: none;

--- a/docs/_sass/foodrem.scss
+++ b/docs/_sass/foodrem.scss
@@ -273,9 +273,16 @@ html {
     }
 
     visibility: hidden;
+    opacity: 0;
+    transition: opacity ease-in-out 150ms;
+
+    @media screen and (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 
   &:hover > .popup {
+    opacity: 1;
     visibility: visible;
   }
 }


### PR DESCRIPTION
As shown on Telegram.

![telegram-cloud-photo-size-5-6260131700159918690-x](https://user-images.githubusercontent.com/34370238/198859984-ae7877d9-cadf-4fcb-9663-9939ff463c92.jpg)

Pop up on hover as well as auto-linking to glossary item on click. Note that image is outdated, the link has been further styled to differentiate them from normal links.

Syntax:
* Without alias (must be valid key):
  ```markdown
  some text with [[ keyword ]] that is auto-glossaried.
  ```
* With alias:
  ```markdown
  some text with [[ keyword:keywords ]] that are auto-glossaried.
  ```

Closes #423.