### PR TITLE
Add bidirectional header linking

### DIFF
--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -35,3 +35,14 @@
     classes.add("hidden");
   });
 </script>
+<script defer>
+  document.addEventListener("DOMContentLoaded", () => {
+    document
+      .querySelectorAll(
+        "article.post h2:not(.no_toc), article.post h3:not(.no_toc), article.post h4:not(.no_toc)"
+      )
+      .forEach((e) => {
+        e.innerHTML = `<a class="header-backlink" href="#markdown-toc-${e.id}">${e.innerHTML}</a>`;
+      });
+  });
+</script>

--- a/docs/_sass/foodrem.scss
+++ b/docs/_sass/foodrem.scss
@@ -231,6 +231,24 @@ html {
 article.post {
   a {
     color: #00769a;
+
+    &.header-backlink {
+      color: inherit;
+
+      &:hover {
+        text-decoration: none;
+
+        &::after {
+          content: "\21E6\A0 Back to table of contents";
+          margin-left: 1ch;
+          display: inline-block;
+          vertical-align: middle;
+
+          font-size: max(0.6em, 1rem);
+          color: gray;
+        }
+      }
+    }
   }
 
   li p {


### PR DESCRIPTION
Closes #425.

As demo-ed over Telegram. Links are generated on DOM load for easiest and fastest compromise without requiring any JavaScript afterwards.