### PR TITLE
Fix renametag error message for extra prefix bug

### DIFF
--- a/src/main/java/seedu/foodrem/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/foodrem/logic/parser/CliSyntax.java
@@ -1,9 +1,15 @@
 package seedu.foodrem.logic.parser;
 
+import java.util.regex.Pattern;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
 public class CliSyntax {
+    /* Regex to match any of the prefixes */
+    public static final Pattern PREFIX_REGEX = Pattern.compile("\\s+"
+            + "(n|qty|u|bgt|exp|p|r)" + "/");
+
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_ITEM_QUANTITY = new Prefix("qty/");

--- a/src/main/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParser.java
@@ -7,7 +7,6 @@ import seedu.foodrem.commons.core.Messages;
 import seedu.foodrem.logic.commands.tagcommands.RenameTagCommand;
 import seedu.foodrem.logic.parser.CliSyntax;
 import seedu.foodrem.logic.parser.Parser;
-import seedu.foodrem.logic.parser.Prefix;
 import seedu.foodrem.logic.parser.exceptions.ParseException;
 import seedu.foodrem.model.tag.Tag;
 
@@ -41,9 +40,6 @@ public class RenameTagCommandParser implements Parser<RenameTagCommand> {
         final String originalName = matcher.group("originalName").trim();
         final String newName = matcher.group("newName").trim();
 
-        System.out.println(newName);
-        System.out.println(originalName);
-
         if (checkExtraPrefixesInName(originalName) || checkExtraPrefixesInName(newName)) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     RenameTagCommand.getUsage()));
@@ -56,9 +52,7 @@ public class RenameTagCommandParser implements Parser<RenameTagCommand> {
     }
 
     private boolean checkExtraPrefixesInName(String name) {
-        if (name.contains(CliSyntax.PREFIX_NAME.getPrefix())) {
-            return true;
-        }
-        return false;
+        Matcher matcher = CliSyntax.PREFIX_REGEX.matcher(name);
+        return matcher.find();
     }
 }

--- a/src/main/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParser.java
@@ -7,6 +7,7 @@ import seedu.foodrem.commons.core.Messages;
 import seedu.foodrem.logic.commands.tagcommands.RenameTagCommand;
 import seedu.foodrem.logic.parser.CliSyntax;
 import seedu.foodrem.logic.parser.Parser;
+import seedu.foodrem.logic.parser.Prefix;
 import seedu.foodrem.logic.parser.exceptions.ParseException;
 import seedu.foodrem.model.tag.Tag;
 
@@ -40,9 +41,24 @@ public class RenameTagCommandParser implements Parser<RenameTagCommand> {
         final String originalName = matcher.group("originalName").trim();
         final String newName = matcher.group("newName").trim();
 
+        System.out.println(newName);
+        System.out.println(originalName);
+
+        if (checkExtraPrefixesInName(originalName) || checkExtraPrefixesInName(newName)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    RenameTagCommand.getUsage()));
+        }
+
         Tag originalTag = new Tag(originalName);
         Tag renamedTag = new Tag(newName);
 
         return new RenameTagCommand(originalTag, renamedTag);
+    }
+
+    private boolean checkExtraPrefixesInName(String name) {
+        if (name.contains(CliSyntax.PREFIX_NAME.getPrefix())) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/foodrem/model/tag/Tag.java
+++ b/src/main/java/seedu/foodrem/model/tag/Tag.java
@@ -5,12 +5,9 @@ import static seedu.foodrem.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Tag in FoodRem.
- * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
+ * Guarantees: immutable; name is valid
  */
 public class Tag {
-    public static final String EXCEED_MAX_CHARS_MESSAGE_CONSTRAINTS = "Tags names have a max length of 30 characters";
-
-    private static final int MAX_CHAR_LIMIT = 30;
 
     private final TagName tagName;
 
@@ -21,20 +18,11 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), EXCEED_MAX_CHARS_MESSAGE_CONSTRAINTS);
         this.tagName = new TagName(tagName);
     }
 
     public String getName() {
         return this.tagName.toString();
-    }
-
-    /**
-     * Returns {@code true} if a given string is a valid tag name.
-     */
-    public static boolean isValidTagName(String test) {
-        requireNonNull(test);
-        return test.length() <= MAX_CHAR_LIMIT;
     }
 
     @Override

--- a/src/main/java/seedu/foodrem/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/foodrem/storage/JsonAdaptedTag.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.foodrem.model.tag.Tag;
+import seedu.foodrem.model.tag.TagName;
 
 /**
  * Jackson-friendly version of {@link Tag}.
@@ -37,9 +38,6 @@ class JsonAdaptedTag {
      * @throws IllegalArgumentException if there were any data constraints violated in the adapted tag.
      */
     public Tag toModelType() throws IllegalArgumentException {
-        if (!Tag.isValidTagName(tagName)) {
-            throw new IllegalArgumentException(Tag.EXCEED_MAX_CHARS_MESSAGE_CONSTRAINTS);
-        }
         return new Tag(tagName);
     }
 }

--- a/src/test/java/seedu/foodrem/logic/parser/tagcommandparser/NewTagCommandParserTest.java
+++ b/src/test/java/seedu/foodrem/logic/parser/tagcommandparser/NewTagCommandParserTest.java
@@ -2,7 +2,6 @@ package seedu.foodrem.logic.parser.tagcommandparser;
 
 import static seedu.foodrem.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.foodrem.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.foodrem.model.tag.Tag.EXCEED_MAX_CHARS_MESSAGE_CONSTRAINTS;
 import static seedu.foodrem.testutil.TypicalTags.FRUITS;
 import static seedu.foodrem.testutil.TypicalTags.FRUITS_WITH_WHITESPACE;
 import static seedu.foodrem.testutil.TypicalTags.NUMBERS;
@@ -18,6 +17,9 @@ import seedu.foodrem.testutil.TagBuilder;
 
 public class NewTagCommandParserTest {
     private final NewTagCommandParser parser = new NewTagCommandParser();
+    private final int MAX_LENGTH = 20;
+    private final String EXCEED_MAX_CHARS_MESSAGE_CONSTRAINTS =
+            String.format("The tag name should not exceed %d characters", MAX_LENGTH);
 
     @Test
     public void parse_tags_success() {

--- a/src/test/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParserTest.java
+++ b/src/test/java/seedu/foodrem/logic/parser/tagcommandparser/RenameTagCommandParserTest.java
@@ -58,4 +58,14 @@ public class RenameTagCommandParserTest {
                         + CommandTestUtil.VALID_DESC_ITEM_QUANTITY_CUCUMBERS,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, RenameTagCommand.getUsage()));
     }
+
+    @Test
+    public void parse_invalidCommandFailure() {
+        // invalid args
+        assertParseFailure(parser,
+                CommandTestUtil.VALID_DESC_TAG_NAME_FRUITS_WITH_WHITESPACES
+                        + CommandTestUtil.VALID_DESC_TAG_NAME_FRUITS_WITH_WHITESPACES
+                        + CommandTestUtil.VALID_DESC_TAG_NAME_FRUITS_WITH_WHITESPACES,
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, RenameTagCommand.getUsage()));
+    }
 }

--- a/src/test/java/seedu/foodrem/model/tag/TagTest.java
+++ b/src/test/java/seedu/foodrem/model/tag/TagTest.java
@@ -26,12 +26,6 @@ public class TagTest {
     }
 
     @Test
-    void isValidTagName() {
-        // null tag name
-        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
-    }
-
-    @Test
     void testEquals_equal() {
         final Tag tagCopy = new Tag(TAGNAME);
         assertEquals(tagCopy, initialTag);


### PR DESCRIPTION
Resolves #406 

This bug is specific only to the rename tag command since the ordering of prefix matters. To give the right error message, we will check for the presence of flags (using Prefix Regex) in the name (since flags with '/' are not allowed), after which we will validate the tag names as usual (checking name length, etc).

Removed the duplicate validation of tag name in Tag class since TagName class does the validation as well.