### PR TITLE
Always check against PR creator for PPP

### DIFF
--- a/.github/workflows/check-ppp-edited.yml
+++ b/.github/workflows/check-ppp-edited.yml
@@ -46,4 +46,4 @@ jobs:
         run: "echo '${{ steps.get_latest_prs.outputs.data }}' > data.json"
       - name: Validate all PRs are included in PPP
         working-directory: ${{ github.workspace }}/cli-test
-        run: ./check-ppp-is-complete.sh ${{ github.actor }}
+        run: ./check-ppp-is-complete.sh ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
Fixes a bug as previously it checks against the author of the last commit that triggered the workflow