### PR TITLE
Fix extra whitespace in autoglossary items

### DIFF
--- a/docs/_includes/autoglossary.liquid
+++ b/docs/_includes/autoglossary.liquid
@@ -12,10 +12,7 @@
 -%}
 {{ nodes.first }}
 {%- for node in nodes offset:1 -%}
-  {% assign data = node | split: ']]' %}
-  {% assign tag = data | first | strip | split: ':' %}
-  {% assign key = tag | first | strip %}
-  {% assign label = tag | last | strip %}
+  {% assign data = node | split: ']]' %}{% assign tag = data | first | strip | split: ':' %}{% assign key = tag | first | strip %}{% assign label = tag | last | strip %}
   {%- if entry_keys contains key -%}
     {%- for entry in site.glossary -%}
       {%- if entry_keys[forloop.index0] == key -%}
@@ -25,8 +22,7 @@
             <i>Click to view glossary</i>
           </span>
         </span>{% break %}
-      {% endif %}
-    {% endfor %}
+      {% endif %}{% endfor %}
     {%- for tail in data offset:1 -%}
       {{ tail }}
     {%- endfor -%}


### PR DESCRIPTION
There was an extra whitespace between the span and other inline elements.

Example:

Source code:
```markdown
* Item ([[ quantity ]])
```

Before:
<img width="154" alt="image" src="https://user-images.githubusercontent.com/34370238/200143724-5611ab7e-0338-4d97-a46e-2c3b4991c9fa.png">


After:
<img width="152" alt="image" src="https://user-images.githubusercontent.com/34370238/200143713-86032cbb-d4d7-41a3-b51a-854c36290429.png">


No change in functionality:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/34370238/200143748-796e2ae7-3b5d-4fc3-ae57-82f783603193.png">

Closes #512.