### PR TITLE
Fix PDF building script

### DIFF
--- a/docs/make-pdf.sh
+++ b/docs/make-pdf.sh
@@ -7,9 +7,7 @@ mkdir -p release
 bundle exec jekyll build
 SHA="$(docker run --rm -dit -p 8080:80 -v "$(pwd)/_site":/usr/local/apache2/htdocs/ httpd:2.4)"
 
-alias makepdf="docker run --network host --rm -v $(pwd):/data michaelperrin/prince --javascript"
-makepdf -o /data/release/DeveloperGuide.pdf http://localhost:8080/DeveloperGuide.html
-makepdf -o /data/release/UserGuide.pdf http://localhost:8080/UserGuide.html
-unalias makepdf
+docker run --network host --rm -v $(pwd):/data michaelperrin/prince --javascript -o /data/release/DeveloperGuide.pdf http://localhost:8080/DeveloperGuide.html
+docker run --network host --rm -v $(pwd):/data michaelperrin/prince --javascript -o /data/release/UserGuide.pdf http://localhost:8080/UserGuide.html
 
 docker stop "$SHA"


### PR DESCRIPTION
Turns out aliases are not on by default inside shell scripts.