### PR TITLE
Fix broken glossary links

### DIFF
--- a/docs/_glossary/CommandInputBox.md
+++ b/docs/_glossary/CommandInputBox.md
@@ -5,4 +5,4 @@ show-in: [ug, dg]
 
 The region located at the top-left of FoodRem's main window.
 
-To view more information, refer to the [Layout](/UserGuide.html#layout) section of the User Guide.
+To view more information, refer to the [Layout]({{ "/UserGuide.html#layout" | relative_url }}) section of the User Guide.

--- a/docs/_glossary/CommandOutputBox.md
+++ b/docs/_glossary/CommandOutputBox.md
@@ -5,4 +5,4 @@ show-in: [ug, dg]
 
 The region located at the right half of FoodRem's main window.
 
-To view more information, refer to the [Layout](/UserGuide.html#layout) section of the User Guide.
+To view more information, refer to the [Layout]({{ "/UserGuide.html#layout" | relative_url }}) section of the User Guide.


### PR DESCRIPTION
It was causing a broken link when `jekyll serve` or deployment is done with a base URL (as in the case in the actual deployment).

Piping to `relative_url` automatically prefixes the URL correctly.