### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,12 @@ jobs:
         run: ./gradlew shadowJar
       - name: Generate tag name from time
         id: tagname
-        run: echo ::set-output name=TAGNAME::$(echo ${{ github.event.repository.pushed_at }} | sed -e 's/^../AR/')
+        run: echo ::set-output name=TAGNAME::$(echo $(date +%s) | sed -e 's/^../AR/')
       - name: Generate release name from time
         id: releasename
-        run: echo "::set-output name=RELEASENAME::$(date -d @${{ github.event.repository.pushed_at }})"
+        run: echo "::set-output name=RELEASENAME::$(date '%e %b %Y, %H:%M %Z')"
+        env:
+          TZ: Asia/Singapore
       - name: Create release on GitHub
         id: create_release # We need the id to refer to it in the next step
         uses: actions/create-release@v1


### PR DESCRIPTION
GitHub seems to have changed the `github.event.repository.pushed_at` value from a UNIX timestamp to a natural one sometime in the past 3 years.

This PR fixes it to restore the ability to auto build JAR files and PDFs from a given release on merge.

It also updates the generated timestamps to Singapore Time.